### PR TITLE
Adopt minimalist Apple-inspired UI theme

### DIFF
--- a/potencial_tile.py
+++ b/potencial_tile.py
@@ -17,21 +17,21 @@ class TileIntersectionApp:
         self.root.title("Определение тайлов")
         self.root.geometry("830x560")
         self.root.resizable(False, False)
-        self.root.configure(bg="#f0f2f5")
+        self.root.configure(bg="#f5f5f7")
 
         self.file_path = None
         self.match_file_path = r"\\corp.tele2.ru\operations_MR\Operations_All\Потенциал_рынка\яархив_исходники\T_Potential\T_Potential_filtered_last.txt"
         self.input_format = 'wkt'
 
-        # Цвета и шрифты
-        self.bg_color = "#f0f2f5"
+        # Цвета и шрифты в минималистичном стиле Apple
+        self.bg_color = "#f5f5f7"
         self.frame_bg = "white"
-        self.font_bold = ("Segoe UI", 11, "bold")
-        self.font_normal = ("Segoe UI", 10)
-        self.accent_color = "#0078D7"  # Синий Microsoft-style
-        self.success_color = "#28a745"
-        self.error_color = "#c0392b"
-        self.grey_text = "#454649"
+        self.font_bold = ("Helvetica Neue", 11, "bold")
+        self.font_normal = ("Helvetica Neue", 10)
+        self.accent_color = "#007aff"  # Синий Apple-style
+        self.success_color = "#34c759"
+        self.error_color = "#ff3b30"
+        self.grey_text = "#8e8e93"
 
         frame = tk.Frame(self.root, bg=self.bg_color)
         frame.pack(fill="both", expand=True, padx=15, pady=15)
@@ -57,44 +57,49 @@ class TileIntersectionApp:
         self.file_label_text = tk.StringVar()
         self.update_file_label_text()
         label_file_desc = tk.Label(input_file_frame, textvariable=self.file_label_text, bg=self.frame_bg,
-                                fg="black", font=self.font_normal, anchor="w")
+                                fg="#1c1c1e", font=self.font_normal, anchor="w")
         label_file_desc.pack(fill="x", padx=10, pady=(10, 3))
 
         btn_file = tk.Button(input_file_frame, text="Выбрать исходный файл", command=self.load_file,
                             bg=self.accent_color, fg="white", font=self.font_bold,
-                            activebackground="#005a9e", cursor="hand2", relief="flat", padx=15, pady=5)
+                            activebackground="#0051a8", cursor="hand2", relief="flat", padx=15, pady=5)
         btn_file.pack(padx=10, pady=(0, 10), anchor='w')
-        btn_file.bind("<Enter>", lambda e: btn_file.config(bg="#005a9e"))
+        btn_file.bind("<Enter>", lambda e: btn_file.config(bg="#0051a8"))
         btn_file.bind("<Leave>", lambda e: btn_file.config(bg=self.accent_color))
 
         self.filename_label = tk.Label(input_file_frame, text="", bg=self.frame_bg, fg=self.grey_text,
-                                    font=("Segoe UI", 9, "italic"), anchor="w")
+                                    font=("Helvetica Neue", 9, "italic"), anchor="w")
         self.filename_label.pack(fill="x", padx=10, pady=(0, 10))
 
         # --- Прогресс ---
         progress_frame = tk.Frame(frame, bg=self.bg_color)
         progress_frame.pack(fill="x", pady=(10, 10))
 
-        self.progress = ttk.Progressbar(progress_frame, orient=tk.HORIZONTAL, length=680, mode='determinate')
+        style = ttk.Style()
+        style.configure("Accent.Horizontal.TProgressbar", troughcolor=self.bg_color,
+                        bordercolor=self.bg_color, background=self.accent_color,
+                        lightcolor=self.accent_color, darkcolor=self.accent_color)
+        self.progress = ttk.Progressbar(progress_frame, orient=tk.HORIZONTAL, length=680,
+                                        mode='determinate', style="Accent.Horizontal.TProgressbar")
         self.progress.pack(side="left", padx=(0, 10), pady=5)
 
         self.counter_var = tk.StringVar(value="")
-        self.counter_label = tk.Label(progress_frame, textvariable=self.counter_var, fg="#34495e",
+        self.counter_label = tk.Label(progress_frame, textvariable=self.counter_var, fg="#3a3a3c",
                                     bg=self.bg_color, font=self.font_normal)
         self.counter_label.pack(side="left", pady=5)
 
         # --- Кнопка запуска обработки ---
         self.btn_process = tk.Button(
             frame, text="Начать обработку", state=tk.DISABLED, command=self.start_processing,
-            bg=self.accent_color, fg='white', font=self.font_bold, activebackground="#005a9e",
+            bg=self.accent_color, fg='white', font=self.font_bold, activebackground="#0051a8",
             cursor="hand2", relief="flat", padx=25, pady=8
         )
         self.btn_process.pack(pady=20)
         # Обеспечиваем белый цвет текста при наведении и уходе мыши
-        self.btn_process.bind("<Enter>", lambda e: self.btn_process.config(bg="#005a9e", fg='white'))
+        self.btn_process.bind("<Enter>", lambda e: self.btn_process.config(bg="#0051a8", fg='white'))
         self.btn_process.bind("<Leave>", lambda e: self.btn_process.config(bg=self.accent_color, fg='white'))
 
-        self.result = tk.Label(frame, text="", fg="#2c3e50", bg=self.bg_color,
+        self.result = tk.Label(frame, text="", fg="#1c1c1e", bg=self.bg_color,
                             justify='left', wraplength=780, font=self.font_normal)
         self.result.pack(pady=10)
 


### PR DESCRIPTION
## Summary
- Refresh UI palette and typography for a cleaner Apple-style look
- Harmonize buttons and progress indicator with unified accent color
- Tweak text colors and hover states for a lighter, smoother feel

## Testing
- `python -m py_compile potencial_tile.py`


------
https://chatgpt.com/codex/tasks/task_e_689b3a6bb11c832d96582809090ec114