### PR TITLE
Ensure s2_cell_id_13 filled for unmatched tile IDs

### DIFF
--- a/potencial_tile.py
+++ b/potencial_tile.py
@@ -228,6 +228,9 @@ class ProcessingWorker(QtCore.QObject):
             suffixes=('', '_spr')
         )
 
+        if 's2_cell_id_13' in merged.columns:
+            merged['s2_cell_id_13'] = merged['s2_cell_id_13'].fillna(merged['tile_id'])
+
         if 'tile_id' in merged.columns:
             merged.drop(columns=['tile_id'], inplace=True)
 


### PR DESCRIPTION
## Summary
- Always populate `s2_cell_id_13` with each point's `tile_id`
- Prevents empty/NaN `s2_cell_id_13` when no match in external dataset

## Testing
- `python -m py_compile potencial_tile.py`


------
https://chatgpt.com/codex/tasks/task_e_689ee6b111d8832d9627afbe6c6419e5